### PR TITLE
Data generator fixes

### DIFF
--- a/tools/driver.c
+++ b/tools/driver.c
@@ -554,9 +554,9 @@ main (int ac, char **av)
          */
          if (kFirstRow != 1)
          {
-            row_skip(i, (int)(kFirstRow - 1));
+            row_skip(i, kFirstRow - 1);
             if (pT->flags & FL_PARENT)
-               row_skip(pT->nParam, (int)(kFirstRow - 1));
+               row_skip(pT->nParam, kFirstRow - 1);
          }
          
          /*

--- a/tools/scaling.c
+++ b/tools/scaling.c
@@ -113,8 +113,7 @@ getScaleSlot(int nTargetGB)
 static ds_key_t
 LogScale(int nTable, int nTargetGB)
 {
-	int nIndex = 1,
-		nDelta,
+	int nDelta,
       i;
 	float fOffset;
 	ds_key_t hgRowcount = 0;
@@ -125,7 +124,7 @@ LogScale(int nTable, int nTargetGB)
 	fOffset = (float)(nTargetGB - arScaleVolume[i - 1])/(float)(arScaleVolume[i] -  arScaleVolume[i - 1]);
 
 	hgRowcount = (int)(fOffset * (float)nDelta);
-	hgRowcount += dist_weight(NULL, "rowcounts", nTable + 1, nIndex);
+	hgRowcount += dist_weight(NULL, "rowcounts", nTable + 1, i);
 
 
 	return(hgRowcount);


### PR DESCRIPTION
Fixes for 2 issues:
1) row_skip call causes overflow on large fact tables leading to incorrectly initialized RNG when using partitioned generation:
```
$ ./dsdgen -filter Y -abr ss -child 1 -parallel 100 -sc 10000 -q| head -n 1
2451813|65495|340499|3167006|591617|3428|1424839|898|61|1|79|11.41|18.71|2.80|99.54|221.20|901.39|1478.09|6.08|99.54|121.66|127.74|-779.73|
$ ./dsdgen -filter Y -abr ss -child 90 -parallel 100 -sc 10000 -q | head -n 1
2451406|71221|146432|41870802|1841002|6402|29365849|296|700|2136000001|41|39.53|78.26|13.30|0.00|545.30|1620.73|3208.66|16.35|0.00|545.30|561.65|-1075.43|
$ ./dsdgen -filter Y -abr ss -child 91 -parallel 100 -sc 10000 -q | head -n 1
2451813|65495|340499|3167006|591617|3428|1424839|898|61|2160000001|79|11.41|18.71|2.80|99.54|221.20|901.39|1478.09|6.08|99.54|121.66|127.74|-779.73|
$ ./dsdgen -filter Y -abr ss -child 92 -parallel 100 -sc 10000 -q | head -n 1
2451813|65495|340499|3167006|591617|3428|1424839|898|61|2184000001|79|11.41|18.71|2.80|99.54|221.20|901.39|1478.09|6.08|99.54|121.66|127.74|-779.73|
$ ./dsdgen -filter Y -abr ss -child 93 -parallel 100 -sc 10000 -q | head -n 1
2451813|65495|340499|3167006|591617|3428|1424839|898|61|2208000001|79|11.41|18.71|2.80|99.54|221.20|901.39|1478.09|6.08|99.54|121.66|127.74|-779.73|
```

2) LogScale, which I assume should do linear interpolation of table count based on the closest predefined scale factors, was a non ascending function of the scale factor:
```
$ for i in 1 10 20 30 40 50 60 70 80 90 100 110 120 10001; do printf "%5d:%10d\n" $i `./dsdgen -filter Y -table item -q -sc $i | wc -l`; done
    1:     18000
   10:    102000
   20:     28000
   30:     40000
   40:     52000
   50:     62000
   60:     74000
   70:     86000
   80:     96000
   90:    108000
  100:    204000
  110:     20000
  120:     24000
 1500:     32000
10001:     18000
```
after the fix:
```
$ for i in 1 10 20 30 40 50 60 70 80 90 100 110 120 1500 10001; do printf "%5d:%10d\n" $i `./dsdgen -filter Y -table item -q -sc $i | wc -l`; done
    1:     18000
   10:    102000
   20:    112000
   30:    124000
   40:    136000
   50:    146000
   60:    158000
   70:    170000
   80:    180000
   90:    192000
  100:    204000
  110:    206000
  120:    210000
 1500:    314000
10001:    402000
```
