### PR TITLE
Include params.h in w_store_sales.c and w_web_sales.c

### DIFF
--- a/tools/w_store_sales.c
+++ b/tools/w_store_sales.c
@@ -50,6 +50,7 @@
 #include "permute.h"
 #include "scd.h"
 #include "parallel.h"
+#include "params.h"
 #ifdef JMS
 extern rng_t Streams[];
 #endif

--- a/tools/w_web_sales.c
+++ b/tools/w_web_sales.c
@@ -53,6 +53,7 @@
 #include "permute.h"
 #include "scd.h"
 #include "parallel.h"
+#include "params.h"
 
 struct W_WEB_SALES_TBL g_w_web_sales;
 ds_key_t skipDays(int nTable, ds_key_t *pRemainder);


### PR DESCRIPTION
This is to fix a build issue:

Before this change when running `make OS=MACOS` we get:
```
gcc -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -DYYDEBUG  -DMACOS -g    -c -o w_store_sales.o w_store_sales.c
w_store_sales.c:141:7: error: implicit declaration of function 'is_set_filter' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (!is_set_filter() || is_set_child()) {
             ^
w_store_sales.c:141:26: error: implicit declaration of function 'is_set_child' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        if (!is_set_filter() || is_set_child()) {
                                ^
2 errors generated.
```

